### PR TITLE
Always use the Git SHA for deployments

### DIFF
--- a/bin/deploy_platform.sh
+++ b/bin/deploy_platform.sh
@@ -192,9 +192,7 @@ do
   SecretsConfig="$DEPLOYMENT_REPO/secrets/$ENV-secrets-values.yaml"
   [ -f "$SecretsConfig" ] && HELMCMD="$HELMCMD -f $SecretsConfig"
 
-  [ -z "$CIRCLE_SHA1" ] && HELMCMD="$HELMCMD --set circleSha1=$CIRCLE_SHA1"
-
-  HELMCMD="helm template deploy/$CHARTNAME $HELMCMD --set environmentName=$ENV --set platformEnv=$PLATFORM_ENV"
+  HELMCMD="helm template deploy/$CHARTNAME $HELMCMD --set circleSha1=$CIRCLE_SHA1 --set environmentName=$ENV --set platformEnv=$PLATFORM_ENV"
 
   echo $HELMCMD
   echo "Writing $ENV config to $CONFIG_FILE"

--- a/bin/deploy_platform.sh
+++ b/bin/deploy_platform.sh
@@ -51,10 +51,10 @@ PARAMETERS
     Path to deployment repo
     If not specified, defaults to the assumption that $FB_APPLICATION-deploy is in the same directory as $FB_APPLICATION
 
-  -s, --sha1 (optional)
+  -s, --sha1
 
-    Git sha of code being deployed
-    Docker images are tagged with this and used here to instruct Helm which image needs pulling for deployment
+    Git sha of the code to be deployed
+    Ensure this value is set when running this script
 
   -c, --context (optional)
 
@@ -148,6 +148,11 @@ if [ "$PLATFORM_ENV" = "" ]; then
 
   "
   usage 1
+fi
+
+if [ "$CIRCLE_SHA1" = "" ]; then
+    echo "--sha1 must be set";
+    exit 1;
 fi
 
 DEP_LENGTH=${#DEPLOYMENT_ENVS[@]}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-deploy-utils",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-deploy-utils",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-deploy-utils",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Utility scripts to deploy Form Builder applications",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-deploy-utils",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Utility scripts to deploy Form Builder applications",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This was optional but given we will always be deploying through CircleCI,
there is no need to guard against it not being present.