### PR TITLE
Add rubocop yml file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,32 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rails.yml
+
+require: rubocop-rspec
+
+AllCops:
+  # Exclude anything that isn't really part of our code.
+  # rails_helper is excluded because it's full of solecisms, but it's mostly
+  # generated code and copy-and-pasted snipets from READMEs.
+  Exclude:
+    - "vendor/**/*"
+    - "db/**/*"
+    - "bin/**/*"
+    - "config/**/*"
+    - "tmp/**/*"
+
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: no_comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: no_comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: no_comma
+
+Metrics/BlockLength:
+  ExcludedMethods: ['describe', 'context', 'let']


### PR DESCRIPTION
[Trello card](https://trello.com/c/3IU1ZDGd/401-add-linting-to-submitter)

## Context

The idea is to start centralised everything about deployment in one place.

So this PRs adds a common rubocop.yml file (inherited from gov UK) to be used across all ruby repos.