### PR TITLE
Add pentest as potential choice when building images

### DIFF
--- a/bin/deploy_platform.sh
+++ b/bin/deploy_platform.sh
@@ -42,7 +42,7 @@ PARAMETERS
 
   -p, --platform
 
-    test|integration|live
+    test|pentest|live
 
     Platform environment to deploy to
   $DEPLOYMENT_ENV_USAGE

--- a/bin/restart_platform_pods.sh
+++ b/bin/restart_platform_pods.sh
@@ -42,7 +42,7 @@ PARAMETERS
 
   -p, --platform
 
-    test|integration|live
+    test|pentest|live
 
     Platform environment to restart pods in
   $DEPLOYMENT_ENV_USAGE

--- a/lib/build_push.js
+++ b/lib/build_push.js
@@ -24,7 +24,7 @@ const buildPush = (name, images) => {
       type: 'string',
       choices: [
         'test',
-        'integration',
+        'pentest',
         'live'
       ],
       conflicts: 'target'
@@ -51,7 +51,7 @@ const buildPush = (name, images) => {
     config.getUsageInstance().showHelp()
     process.stdout.write(`
     Invalid values:
-        Argument: platform, Choices: "test", "integration", "live"`)
+        Argument: platform, Choices: "test", "pentest", "live"`)
     process.exit(1)
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ministryofjustice/fb-deploy-utils",
-  "version": "1.0.16",
+  "version": "1.1.0",
   "description": "Utility scripts to deploy Form Builder applications",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
CircleCI were returning error for new environments like

```
Invalid values:
  Argument: platform, Given: "pentest", Choices: "test", "integration", "live"
```